### PR TITLE
consumer: add option to force valid utf-8 strings

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -49,6 +49,7 @@ type ConsumeFuzzer struct {
 	NumberOfCalls        int
 	position             uint32
 	fuzzUnexportedFields bool
+	forceUTF8Strings     bool
 	curDepth             int
 	Funcs                map[reflect.Type]reflect.Value
 }
@@ -103,6 +104,14 @@ func (f *ConsumeFuzzer) AllowUnexportedFields() {
 
 func (f *ConsumeFuzzer) DisallowUnexportedFields() {
 	f.fuzzUnexportedFields = false
+}
+
+func (f *ConsumeFuzzer) AllowNonUTF8Strings() {
+	f.forceUTF8Strings = false
+}
+
+func (f *ConsumeFuzzer) DisallowNonUTF8Strings() {
+	f.forceUTF8Strings = true
 }
 
 func (f *ConsumeFuzzer) GenerateStruct(targetStruct interface{}) error {
@@ -461,7 +470,11 @@ func (f *ConsumeFuzzer) GetString() (string, error) {
 		return "nil", errors.New("numbers overflow")
 	}
 	f.position = byteBegin + length
-	return string(f.data[byteBegin:f.position]), nil
+	s := string(f.data[byteBegin:f.position])
+	if f.forceUTF8Strings {
+		s = strings.ToValidUTF8(s, "")
+	}
+	return s, nil
 }
 
 func (f *ConsumeFuzzer) GetBool() (bool, error) {


### PR DESCRIPTION
Some use cases like JSON serialization require that string values are valid UTF-8. This patch adds a configuration option to the consumer that allows the end user to opt into forcing this constraint on generated strings. It works by using the strings.ToValidUTF8() helper to strip away non-UTF-8 characters.

For backward compatbility and because this is not a generally-applicable constraint, we keep the default behaviour the same as it was before and make the new configuration option opt-in via the ConsumeFuzzer.DisallowNonUTF8Strings() function.